### PR TITLE
Replace http-echo image

### DIFF
--- a/test-data/base-valid.yaml
+++ b/test-data/base-valid.yaml
@@ -14,8 +14,8 @@ spec:
     spec:
       containers:
       - name: http-echo
-        image: hashicorp/http-echo
-        args: ["-text", "hello-world"]
+        image: jxlwqq/http-echo
+        args: ["--text", "hello-world"]
         ports:
         - containerPort: 5678        
 ---

--- a/test-data/kubeval-invalid.yaml
+++ b/test-data/kubeval-invalid.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       containers:
       - name: http-echo
-        image: hashicorp/http-echo
-        args: ["-text", "hello-world"]
+        image: jxlwqq/http-echo
+        args: ["--text", "hello-world"]
         ports:
         - containerPort: 5678        
 ---


### PR DESCRIPTION
This replaces hashicorp/http-echo by https://github.com/jxlwqq/http-echo
image which is a multiplatform image and hence the demos will work for
Apple M1 architecture.

Fix for https://github.com/amitsaha/kubernetes-static-checkers-demo/issues/1