### PR TITLE
fixed mismatched containerPort

### DIFF
--- a/test-data/base-valid.yaml
+++ b/test-data/base-valid.yaml
@@ -17,7 +17,7 @@ spec:
         image: jxlwqq/http-echo
         args: ["--text", "hello-world"]
         ports:
-        - containerPort: 5678        
+        - containerPort: 8080        
 ---
 apiVersion: v1
 kind: Service
@@ -27,6 +27,6 @@ spec:
   ports:
   - port: 5678
     protocol: TCP
-    targetPort: 5678
+    targetPort: 8080
   selector:
     app: http-echo


### PR DESCRIPTION
I started with the lesson at https://learnk8s.io/validating-kubernetes-yaml and encountered a few typos as I went along. Thank you for the experience of troubleshooting and debugging these scripts.
----
when changing from hashicorp/http-echo to  jxlwqq/http-echo the containerPort needed to also be changed.  hashicorp used 5678 whereas jxlwgg exposes 8080 per https://github.com/jxlwqq/http-echo
I left the service exposed port as 5678 because the lesson references in mid-text.
----
p.s. the lesson https://learnk8s.io/validating-kubernetes-yaml also has a typo in line 18 the args should be "--text" rather than "-text".  That is what drew me to this repository/fork/branch